### PR TITLE
Fix club button text wrapping to single line

### DIFF
--- a/src/components/ClubsPage.css
+++ b/src/components/ClubsPage.css
@@ -83,6 +83,7 @@
   line-height: 20px;
   letter-spacing: 0.1px;
   color: #0D0D0D;
+  white-space: nowrap;
 }
 
 .new-club-btn:hover {


### PR DESCRIPTION
## Purpose
Fix button text that was wrapping to two lines when it should display on a single line, as requested by the user for better visual consistency.

## Code changes
Added `white-space: nowrap` CSS property to the club button styling in `ClubsPage.css` to prevent text from wrapping to multiple lines.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 3`

🔗 [Edit in Builder.io](https://builder.io/app/projects/0d4404456a3e4591a37a58eb37a408ab/pixel-verse)

👀 [Preview Link](https://0d4404456a3e4591a37a58eb37a408ab-pixel-verse.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>0d4404456a3e4591a37a58eb37a408ab</projectId>-->
<!--<branchName>pixel-verse</branchName>-->